### PR TITLE
refactor(routers): 限制用户爱好字符串长度

### DIFF
--- a/routers/adminrouter/handlers.go
+++ b/routers/adminrouter/handlers.go
@@ -632,7 +632,7 @@ func updateUserConfig(ctx *gin.Context) {
 		Username:          username,
 		UserEmail:         userEmail,
 		UserGithubAddress: userGithubAddress,
-		UserHobbies:       userHobbies,
+		UserHobbies:       userHobbies[:10],
 		TypeWriterContent: typeWriterContent,
 		BackgroundImage:   config.User.BackgroundImage,
 		AvatarImage:       config.User.AvatarImage,


### PR DESCRIPTION
- 在 adminrouter/handlers.go 文件中，将 userHobbies 字符串长度限制为前 10 个字符
- 这个修改可能用于优化用户爱好信息的显示或存储