### PR TITLE
fix(routers): 修复友链申请错误响应

### DIFF
--- a/routers/webrouter/handlers.go
+++ b/routers/webrouter/handlers.go
@@ -191,7 +191,7 @@ func applyFriendLink(ctx *gin.Context) {
 
 	// 调用service层处理友链申请
 	if err := webservice.ApplyFriendLink(ctx, friendLinkDto); err != nil {
-		resp.Err(ctx, "友链申请失败", err.Error())
+		resp.Err(ctx, "友链申请失败: "+err.Error(), nil)
 		return
 	}
 


### PR DESCRIPTION
- 修改了 resp.Err 的调用方式，统一错误信息格式
- 在错误信息中添加了 err.Error()，提供更多错误细节