### PR TITLE
feat(filetool): 添加 EnsureDir 函数以确保目录存在并递归创建

### DIFF
--- a/pkg/filetool/filetool.go
+++ b/pkg/filetool/filetool.go
@@ -269,6 +269,36 @@ func ForceRemove(path string) error {
 	return nil
 }
 
+// EnsureDir 确保指定的目录存在，如果不存在则创建它。
+// 该函数会递归创建所有必要的父目录。
+//
+// 参数：
+//   - dirPath: 要确保存在的目录路径
+//
+// 返回值：
+//   - error: 如果创建失败则返回错误，成功则返回 nil
+func EnsureDir(dirPath string) error {
+	// 检查目录是否已存在
+	if IsExist(dirPath) {
+		// 验证路径是否为目录
+		fileInfo, err := os.Stat(dirPath)
+		if err != nil {
+			return fmt.Errorf("获取路径信息失败 %s: %w", dirPath, err)
+		}
+		if !fileInfo.IsDir() {
+			return fmt.Errorf("路径存在但不是目录: %s", dirPath)
+		}
+		return nil
+	}
+
+	// 递归创建目录
+	if err := os.MkdirAll(dirPath, 0755); err != nil {
+		return fmt.Errorf("创建目录失败 %s: %w", dirPath, err)
+	}
+
+	return nil
+}
+
 // closeFile 安全关闭文件句柄，如果关闭时发生错误且原错误为空则设置错误。
 func closeFile(f *os.File, err *error) {
 	if cerr := f.Close(); cerr != nil && *err == nil {

--- a/searchengine/searchengine.go
+++ b/searchengine/searchengine.go
@@ -3,6 +3,7 @@ package searchengine
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"sparrow_blog_server/internal/model/dto"
 	"sparrow_blog_server/internal/repositories/blogrepo"
 	"sparrow_blog_server/pkg/config"
@@ -135,6 +136,12 @@ func LoadingIndex(ctx context.Context) error {
 			Index = index
 		} else {
 			logger.Info("创建索引文件")
+
+			// 确保索引文件的目录存在
+			if err := filetool.EnsureDir(filepath.Dir(config.SearchEngine.IndexPath)); err != nil {
+				logger.Panic("创建索引目录失败: " + err.Error())
+			}
+
 			chineseMapping, err := mapping.CreateChineseMapping()
 			if err != nil {
 				logger.Panic("创建中文索引映射失败: " + err.Error())
@@ -365,6 +372,13 @@ func RebuildIndex(ctx context.Context) error {
 
 	// 5. 创建新索引
 	logger.Info("创建新索引文件")
+
+	// 确保索引文件的目录存在
+	indexDir := filepath.Dir(config.SearchEngine.IndexPath)
+	if err := filetool.EnsureDir(indexDir); err != nil {
+		return fmt.Errorf("创建索引目录失败: %w", err)
+	}
+
 	newIndex, err := bleve.New(config.SearchEngine.IndexPath, chineseMapping)
 	if err != nil {
 		return err


### PR DESCRIPTION
- 新增 EnsureDir 函数，确保指定目录存在，如果不存在则递归创建所有必要的父目录。
- 在 searchengine 包中更新 LoadingIndex 和 RebuildIndex 函数，调用 EnsureDir 确保索引文件的目录存在。