### PR TITLE
fix(searchengine): 增强索引关闭错误处理

### DIFF
--- a/searchengine/searchengine.go
+++ b/searchengine/searchengine.go
@@ -444,7 +444,9 @@ func RebuildIndex(ctx context.Context) error {
 	logger.Info("获取所有文档数据")
 	docs, err := getAllDocs(ctx)
 	if err != nil {
-		newIndex.Close()
+		if closeErr := newIndex.Close(); closeErr != nil {
+			logger.Error("关闭新索引失败: " + closeErr.Error())
+		}
 		return err
 	}
 
@@ -456,7 +458,9 @@ func RebuildIndex(ctx context.Context) error {
 	for i, d := range docs {
 		select {
 		case <-ctx.Done():
-			newIndex.Close()
+			if closeErr := newIndex.Close(); closeErr != nil {
+				logger.Error("关闭新索引失败: " + closeErr.Error())
+			}
 			return ctx.Err()
 		default:
 		}


### PR DESCRIPTION
- 在 RebuildIndex 函数中，添加对新索引关闭操作的错误处理，确保在关闭索引失败时记录错误日志。
- 更新文档数据获取和上下文取消处理中的索引关闭逻辑，提升系统的稳定性和可维护性。